### PR TITLE
refactor: replace peter-evans/repository-dispatch with actions/github…

### DIFF
--- a/.github/workflows/webhook-trigger.yml
+++ b/.github/workflows/webhook-trigger.yml
@@ -55,7 +55,13 @@ jobs:
 
       - name: Trigger repository dispatch
         if: success()
-        uses: peter-evans/repository-dispatch@v3
+        uses: actions/github-script@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: stock-update
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'stock-update',
+              client_payload: {}
+            });


### PR DESCRIPTION
…-script

Replace third-party peter-evans/repository-dispatch@v3 with actions/github-script@v7 using github.rest.repos.createDispatchEvent(). This eliminates all non-official GitHub Actions dependencies.